### PR TITLE
Check deletion results before determining success/failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,10 +108,19 @@ class Remover {
         if (!config.prompt) {
           let promisses = [];
           for (const b of config.buckets) {
-            promisses.push(getAllKeys(b).then(executeRemove).then(() => {
-              const message = `Success: ${b} is empty.`;
-              self.log(message);
-              self.serverless.cli.consoleLog(`${messagePrefix}${chalk.yellow(message)}`);
+            promisses.push(getAllKeys(b).then(executeRemove).then((results) => {
+              const errors = []
+              results.forEach((result) => { errors.push(...result.Errors); });
+              if (errors.length === 0) {
+                const message = `Success: ${b} is empty.`;
+                self.log(message);
+                self.serverless.cli.consoleLog(`${messagePrefix}${chalk.yellow(message)}`);
+              } else {
+                const message = `Failed: ${b} may not be empty.`;
+                self.log(message);
+                self.log(JSON.stringify(errors));
+                self.serverless.cli.consoleLog(`${messagePrefix}${chalk.yellow(message)}`);
+              }
             }).catch((err) => {
               const message = `Faild: ${b} may not be empty.`;
               self.log(message);


### PR DESCRIPTION
We should look to see if any errors are returned here.

It's possible for errors to exist in these results. For example, if the AWS
user has permission to list the buckets but does not have permission to delete
the bucket items.

Example logs (after applying this patch):

> Serverless: Failed: my-testing-bucket may not be empty.
> Serverless: [[{"Key":"foo","Code":"AccessDenied","Message":"Access Denied"},{"Key":"bar","Code":"AccessDenied","Message":"Access Denied"}]]
> S3 Remover: Failed: my-testing-bucket may not be empty.