### PR TITLE
Fix deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ class Remover {
         options: {
           verbose: {
             usage: 'Increase verbosity',
-            shortcut: 'v'
+            shortcut: 'v',
+            type: 'boolean'
           }
         }
       }


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - Remover for "verbose"
```